### PR TITLE
fix: Use DOCKER_HOST env var for socket path in engine and API containers

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
@@ -191,9 +191,11 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 		usedPorts[debugServerDockerPort] = docker_manager.NewManualPublishingSpec(uint16(apicDebugServerPort))
 	}
 
+	// Get the correct socket path based on DOCKER_HOST or runtime (Docker/Podman)
+	socketPath := shared_helpers.GetDockerSocketPath(backend.dockerManager)
 	bindMounts := map[string]string{
-		// Necessary so that the API container can interact with the Docker engine
-		consts.DockerSocketFilepath: consts.DockerSocketFilepath,
+		// Necessary so that the API container can interact with the Docker/Podman engine
+		socketPath: socketPath,
 	}
 
 	volumeMounts := map[string]string{

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
@@ -279,9 +279,11 @@ func CreateEngine(
 		return nil, stacktrace.Propagate(err, "An error occurred creating Docker config storage.")
 	}
 
+	// Get the correct socket path based on DOCKER_HOST or runtime (Docker/Podman)
+	socketPath := shared_helpers.GetDockerSocketPath(dockerManager)
 	bindMounts := map[string]string{
-		// Necessary so that the engine server can interact with the Docker engine
-		consts.DockerSocketFilepath: consts.DockerSocketFilepath,
+		// Necessary so that the engine server can interact with the Docker/Podman engine
+		socketPath: socketPath,
 	}
 
 	volumeMounts := map[string]string{

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -772,3 +772,23 @@ func dumpContainerInfo(
 
 	return nil
 }
+
+// GetDockerSocketPath returns the Docker socket path to use, checking DOCKER_HOST env var first,
+// then falling back to appropriate defaults for Docker/Podman
+func GetDockerSocketPath(dockerManager *docker_manager.DockerManager) string {
+	// Check if DOCKER_HOST environment variable is set
+	dockerHost := os.Getenv("DOCKER_HOST")
+	if dockerHost != "" {
+		// Extract socket path from DOCKER_HOST (e.g., "unix:///path/to/socket" -> "/path/to/socket")
+		if strings.HasPrefix(dockerHost, "unix://") {
+			return strings.TrimPrefix(dockerHost, "unix://")
+		}
+		// If DOCKER_HOST is set but not a unix socket, fall back to defaults
+	}
+
+	// Fall back to default paths based on Docker/Podman
+	if dockerManager.IsPodman() {
+		return "/run/podman/podman.sock"
+	}
+	return consts.DockerSocketFilepath
+}


### PR DESCRIPTION
## Summary
- Fixes the hardcoded Docker socket path that causes failures when using Podman or custom Docker configurations
- Resolves the "statfs /var/run/docker.sock: permission denied" error in CI environments

## Problem
When creating Kurtosis engine and API containers, the code was hardcoding `/var/run/docker.sock` as the socket path. This fails in environments using:
- Podman (which uses `/run/podman/podman.sock`)
- Custom Docker configurations with `DOCKER_HOST` environment variable
- CI/CD environments with non-standard socket locations

## Solution
Added a `GetDockerSocketPath()` helper function that:
1. First checks the `DOCKER_HOST` environment variable
2. Extracts the socket path if it's a unix socket (e.g., `unix:///custom/path/socket.sock`)
3. Falls back to runtime-specific defaults:
   - `/run/podman/podman.sock` for Podman
   - `/var/run/docker.sock` for Docker

## Changes
- Added `GetDockerSocketPath()` helper in `shared_helpers.go`
- Updated engine container creation to use dynamic socket path
- Updated API container creation to use dynamic socket path
- Both bind mount and container path now use the correct socket location

## Test Plan
- [ ] Test with standard Docker installation
- [ ] Test with Podman runtime
- [ ] Test with custom `DOCKER_HOST` environment variable
- [ ] Verify CI pipeline with self-hosted runners using Podman

This ensures Kurtosis can properly create engine and API containers regardless of the container runtime configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)