### PR TITLE
fix: Correctly map host socket to container's /var/run/docker.sock

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
@@ -192,10 +192,11 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 	}
 
 	// Get the correct socket path based on DOCKER_HOST or runtime (Docker/Podman)
-	socketPath := shared_helpers.GetDockerSocketPath(backend.dockerManager)
+	hostSocketPath := shared_helpers.GetDockerSocketPath(backend.dockerManager)
 	bindMounts := map[string]string{
 		// Necessary so that the API container can interact with the Docker/Podman engine
-		socketPath: socketPath,
+		// Map the host socket to the standard location inside the container
+		hostSocketPath: consts.DockerSocketFilepath,
 	}
 
 	volumeMounts := map[string]string{

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
@@ -280,10 +280,11 @@ func CreateEngine(
 	}
 
 	// Get the correct socket path based on DOCKER_HOST or runtime (Docker/Podman)
-	socketPath := shared_helpers.GetDockerSocketPath(dockerManager)
+	hostSocketPath := shared_helpers.GetDockerSocketPath(dockerManager)
 	bindMounts := map[string]string{
 		// Necessary so that the engine server can interact with the Docker/Podman engine
-		socketPath: socketPath,
+		// Map the host socket to the standard location inside the container
+		hostSocketPath: consts.DockerSocketFilepath,
 	}
 
 	volumeMounts := map[string]string{

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/consts.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/consts.go
@@ -28,7 +28,7 @@ entryPoints:
 
 providers:
   docker:
-    endpoint: "unix://{{ .SocketPath }}"
+    endpoint: "unix:///var/run/docker.sock"
     exposedByDefault: false
     network: "{{ .NetworkId }}"
 `


### PR DESCRIPTION
Fixed the bind mount mapping to ensure the socket is always available at /var/run/docker.sock inside containers, regardless of the host's socket location.

Changes:
- Map host socket path (from DOCKER_HOST or runtime) to /var/run/docker.sock in container
- Simplified Traefik config - no need to template the socket path
- Socket is always at standard location inside all containers

This ensures compatibility while maintaining the expected socket location inside the containers.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES/NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
