### PR TITLE
refactor: Use shared GetDockerSocketPath function in Traefik config

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/traefik_container_config_provider_factory.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/traefik_container_config_provider_factory.go
@@ -1,9 +1,7 @@
 package traefik
 
 import (
-	"os"
-	"strings"
-
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/reverse_proxy"
 )
@@ -11,27 +9,8 @@ import (
 func createTraefikContainerConfigProvider(httpPort uint16, dashboardPort uint16, networkId string, dockerManager *docker_manager.DockerManager) *traefikContainerConfigProvider {
 	config := reverse_proxy.NewDefaultReverseProxyConfig(httpPort, dashboardPort, networkId)
 
-	// Determine socket path, prioritizing DOCKER_HOST environment variable
-	socketPath := getSocketPath(dockerManager)
+	// Determine socket path using the shared helper function
+	socketPath := shared_helpers.GetDockerSocketPath(dockerManager)
 
 	return newTraefikContainerConfigProvider(config, socketPath)
-}
-
-func getSocketPath(dockerManager *docker_manager.DockerManager) string {
-	// Check if DOCKER_HOST environment variable is set
-	dockerHost := os.Getenv("DOCKER_HOST")
-	if dockerHost != "" {
-		// Extract socket path from DOCKER_HOST (e.g., "unix:///path/to/socket" -> "/path/to/socket")
-		if strings.HasPrefix(dockerHost, "unix://") {
-			return strings.TrimPrefix(dockerHost, "unix://")
-		}
-		// If DOCKER_HOST is set but not a unix socket, fall back to defaults
-	}
-
-	// Fall back to default paths based on Docker/Podman
-	if dockerManager.IsPodman() {
-		return "/run/podman/podman.sock"
-	} else {
-		return "/var/run/docker.sock"
-	}
 }


### PR DESCRIPTION
Removed duplicate socket path detection logic from the Traefik container config provider factory and replaced it with the shared GetDockerSocketPath helper function.

This eliminates code duplication and ensures consistent socket path resolution across all components.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES/NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
