### PR TITLE
feat: Add environment variable overrides for engine and core images

### DIFF
--- a/core/launcher/api_container_launcher/api_container_launcher.go
+++ b/core/launcher/api_container_launcher/api_container_launcher.go
@@ -7,6 +7,8 @@ package api_container_launcher
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/api_container"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
@@ -20,9 +22,21 @@ import (
 const (
 	enclaveDataVolumeDirpath = "/kurtosis-data"
 
-	// TODO This should come from the same logic that builds the server image!!!!!
-	containerImage = "kurtosistech/core"
+	// Default core image, can be overridden via KURTOSIS_CORE_IMAGE env var
+	defaultContainerImage = "kurtosistech/core"
+	coreImageEnvVar       = "KURTOSIS_CORE_IMAGE"
 )
+
+// containerImage is the actual image to use, checking env var override first
+var containerImage = getImageWithEnvOverride(coreImageEnvVar, defaultContainerImage)
+
+func getImageWithEnvOverride(envVar, defaultImage string) string {
+	if override := os.Getenv(envVar); override != "" {
+		logrus.Infof("Using custom core image from %s: %s", envVar, override)
+		return override
+	}
+	return defaultImage
+}
 
 type ApiContainerLauncher struct {
 	kurtosisBackend backend_interface.KurtosisBackend

--- a/engine/launcher/engine_server_launcher/engine_server_launcher.go
+++ b/engine/launcher/engine_server_launcher/engine_server_launcher.go
@@ -8,6 +8,7 @@ package engine_server_launcher
 import (
 	"context"
 	"net"
+	"os"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/logs_aggregator"
@@ -21,9 +22,21 @@ import (
 )
 
 const (
-	// TODO This should come from the same logic that builds the server image!!!!!
-	containerImage = "kurtosistech/engine"
+	// Default engine image, can be overridden via KURTOSIS_ENGINE_IMAGE env var
+	defaultContainerImage = "kurtosistech/engine"
+	engineImageEnvVar     = "KURTOSIS_ENGINE_IMAGE"
 )
+
+// containerImage is the actual image to use, checking env var override first
+var containerImage = getImageWithEnvOverride(engineImageEnvVar, defaultContainerImage)
+
+func getImageWithEnvOverride(envVar, defaultImage string) string {
+	if override := os.Getenv(envVar); override != "" {
+		logrus.Infof("Using custom engine image from %s: %s", envVar, override)
+		return override
+	}
+	return defaultImage
+}
 
 type EngineServerLauncher struct {
 	kurtosisBackend backend_interface.KurtosisBackend


### PR DESCRIPTION
Allow custom engine and core (API container) images to be specified via environment variables, making it easier to test custom builds in CI/CD.

Environment variables:
- KURTOSIS_ENGINE_IMAGE: Override for engine image (default: kurtosistech/engine)
- KURTOSIS_CORE_IMAGE: Override for core/API image (default: kurtosistech/core)

This enables users to:
1. Build custom images with fixes or modifications
2. Push them to their own registry
3. Use them without modifying code

Example usage:
```bash
export KURTOSIS_ENGINE_IMAGE="myregistry/kurtosis-engine:custom"
export KURTOSIS_CORE_IMAGE="myregistry/kurtosis-core:custom"
kurtosis run ...
```

The launcher will log when custom images are being used for visibility.

🤖 Generated with [Claude Code](https://claude.ai/code)