### PR TITLE
refactor: Forward env vars from CLI to engine container

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net"
-	"os"
 	"time"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_registry_spec"
@@ -133,11 +132,6 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 	}
 	for key, value := range customEnvVars {
 		envVars[key] = value
-	}
-
-	// Pass DOCKER_HOST environment variable if it exists
-	if dockerHost := os.Getenv("DOCKER_HOST"); dockerHost != "" {
-		envVars["DOCKER_HOST"] = dockerHost
 	}
 
 	defaultWait, err := port_spec.CreateWaitWithDefaultValues()

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
@@ -3,6 +3,7 @@ package engine_functions
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator"
@@ -307,6 +308,14 @@ func CreateEngine(
 	labelStrs := map[string]string{}
 	for labelKey, labelValue := range engineAttrs.GetLabels() {
 		labelStrs[labelKey.GetString()] = labelValue.GetString()
+	}
+
+	// Forward environment variables from CLI to Engine container
+	if coreImage := os.Getenv("KURTOSIS_CORE_IMAGE"); coreImage != "" {
+		envVars["KURTOSIS_CORE_IMAGE"] = coreImage
+	}
+	if dockerHost := os.Getenv("DOCKER_HOST"); dockerHost != "" {
+		envVars["DOCKER_HOST"] = dockerHost
 	}
 
 	createAndStartArgsBuilder := docker_manager.NewCreateAndStartContainerArgsBuilder(


### PR DESCRIPTION
## Summary
- Moved environment variable forwarding logic from engine launcher to the `create_engine` function where it belongs
- The CLI now properly forwards `DOCKER_HOST` and `KURTOSIS_CORE_IMAGE` to the engine container
- Simplified API container creation by removing unnecessary DOCKER_HOST forwarding

## Key Changes
1. **CLI's `create_engine` function** forwards environment variables to engine container:
   - `DOCKER_HOST`: For determining correct socket paths when creating bind mounts
   - `KURTOSIS_CORE_IMAGE`: For using custom API container images

2. **API containers** no longer need DOCKER_HOST since they access Docker/Podman through the standard `/var/run/docker.sock` path (where the host socket is mounted)

## Test plan
- [ ] Build custom engine and core images with these changes
- [ ] Set environment variables:
  ```bash
  export DOCKER_HOST=unix:///path/to/podman/socket
  export KURTOSIS_ENGINE_IMAGE=custom-engine:tag
  export KURTOSIS_CORE_IMAGE=custom-core:tag
  ```
- [ ] Verify engine container receives DOCKER_HOST and KURTOSIS_CORE_IMAGE
- [ ] Verify API containers can connect to Docker/Podman daemon through mounted socket

🤖 Generated with [Claude Code](https://claude.ai/code)